### PR TITLE
feat(strategies): implement the initial strategy for dap

### DIFF
--- a/lua/nvim-ginkgo/config.lua
+++ b/lua/nvim-ginkgo/config.lua
@@ -1,0 +1,41 @@
+local M = {}
+
+---@class nvim-ginkgo.Config
+---@field command string[]
+---@field dap nvim-ginkgo.ConfigDap
+
+---@class nvim-ginkgo.ConfigDap
+---@field args string[]
+
+---@type nvim-ginkgo.Config
+local defaults = {
+	command = {
+		"ginkgo",
+		"run",
+		"-v",
+	},
+	dap = {
+		args = {
+			"--ginkgo.v",
+		},
+	},
+}
+
+---@type nvim-ginkgo.Config
+---@diagnostic disable-next-line: missing-fields
+M.options = nil
+
+---@return nvim-ginkgo.Config
+function M.read()
+	return M.options or defaults
+end
+
+---@param config nvim-ginkgo.Config
+---@return nvim-ginkgo.Config
+function M.setup(config)
+	M.options = vim.tbl_deep_extend("force", {}, defaults, config or {})
+
+	return M.options
+end
+
+return M

--- a/lua/nvim-ginkgo/init.lua
+++ b/lua/nvim-ginkgo/init.lua
@@ -141,7 +141,7 @@ function adapter.build_spec(args)
 	}
 
 	if args.strategy == "dap" then
-		dap.setup_debugging(directory)
+		dap.check_dap_available()
 
 		local dap_args = vim.deepcopy(c.dap.args)
 

--- a/lua/nvim-ginkgo/strategies/dap.lua
+++ b/lua/nvim-ginkgo/strategies/dap.lua
@@ -1,0 +1,46 @@
+local M = {}
+
+local logger = require("neotest.logging")
+
+---This will prepare and setup nvim-dap-go for debugging.
+---@param cwd string
+function M.setup_debugging(cwd)
+	local ok, adapter = pcall(require, "dap-go")
+	if not ok then
+		local msg = "You must have leoluz/nvim-dap-go installed to use DAP strategy. "
+			.. "See the neotest-golang README for more information."
+		logger.error(msg)
+		error(msg)
+	end
+
+	local opts = {
+		delve = {
+			cwd = cwd,
+		},
+	}
+	logger.debug({ "Setting up dap-go for DAP: ", opts })
+
+	adapter.setup(opts)
+end
+
+--- @param path string
+--- @param args string[]?
+--- @return table | nil
+function M.get_dap_config(path, args)
+	-- :help dap-configuration
+	local config = {
+		type = "go",
+		name = "Neotest-golang",
+		request = "launch",
+		mode = "test",
+		program = path,
+		args = args,
+		outputMode = "remote",
+	}
+
+	logger.debug({ "DAP configuration: ", config })
+
+	return config
+end
+
+return M

--- a/lua/nvim-ginkgo/strategies/dap.lua
+++ b/lua/nvim-ginkgo/strategies/dap.lua
@@ -2,39 +2,29 @@ local M = {}
 
 local logger = require("neotest.logging")
 
----This will prepare and setup nvim-dap-go for debugging.
----@param cwd string
-function M.setup_debugging(cwd)
-	local ok, adapter = pcall(require, "dap-go")
+---Checks if dap-go is available for debugging.
+function M.check_dap_available()
+	local ok, _ = pcall(require, "dap-go")
 	if not ok then
-		local msg = "You must have leoluz/nvim-dap-go installed to use DAP strategy. "
-			.. "See the neotest-golang README for more information."
+		local msg = "You must have leoluz/nvim-dap-go installed to use DAP strategy."
 		logger.error(msg)
 		error(msg)
 	end
-
-	local opts = {
-		delve = {
-			cwd = cwd,
-		},
-	}
-	logger.debug({ "Setting up dap-go for DAP: ", opts })
-
-	adapter.setup(opts)
 end
 
---- @param path string
---- @param args string[]?
---- @return table | nil
-function M.get_dap_config(path, args)
+---@param cwd string
+---@param args string[]?
+---@return table
+function M.get_dap_config(cwd, args)
 	-- :help dap-configuration
 	local config = {
 		type = "go",
-		name = "Neotest-golang",
+		name = "nvim-ginkgo",
 		request = "launch",
 		mode = "test",
-		program = path,
+		program = cwd,
 		args = args,
+		cwd = cwd,
 		outputMode = "remote",
 	}
 

--- a/lua/nvim-ginkgo/utils.lua
+++ b/lua/nvim-ginkgo/utils.lua
@@ -227,9 +227,9 @@ function utils.create_position_focus(position)
 	local name = string.sub(position.id, string.find(position.id, "::") + 2)
 	name, _ = string.gsub(name, "::", " ")
 	name, _ = string.gsub(name, '"', "")
-	-- TODO: there is a problem with slashes for sure!
+	-- escape forward slashes for regex pattern matching
 	name, _ = string.gsub(name, "/", "\\/")
-	-- escape some pattern characters
+	-- escape regex special characters
 	name, _ = string.gsub(name, "([%.%+%-%*%?%[%]%(%)%$%^%|])", "\\%1")
 
 	-- prepare the pattern

--- a/lua/nvim-ginkgo/utils.lua
+++ b/lua/nvim-ginkgo/utils.lua
@@ -227,9 +227,14 @@ function utils.create_position_focus(position)
 	local name = string.sub(position.id, string.find(position.id, "::") + 2)
 	name, _ = string.gsub(name, "::", " ")
 	name, _ = string.gsub(name, '"', "")
+	-- TODO: there is a problem with slashes for sure!
+	name, _ = string.gsub(name, "/", "\\/")
+	-- escape some pattern characters
+	name, _ = string.gsub(name, "([%.%+%-%*%?%[%]%(%)%$%^%|])", "\\%1")
+
 	-- prepare the pattern
 	-- https://github.com/onsi/ginkgo/issues/1126#issuecomment-1409245937
-	return "'\\b" .. name .. "\\b'"
+	return "\\b" .. name .. "\\b"
 end
 
 return utils


### PR DESCRIPTION
This is a draft merge request for adding the `dap` strategy to this adapter.

The implementation is done like in [fredrikaverpil/neotest-golang)](https://github.com/fredrikaverpil/neotest-golang).

- Adds support for `dap` strategy where the `delve` can debug the `ginkgo` tests.
  - This runs `dlv test` so the arguments of the `ginkgo` tests are a bit different, therefore it can not repurpose the original arguments.
- Adds a setup function.
  - This adds the functionality to configure the base `ginkgo` command to something like `go tool ginkgo` if desired.
  - This adds the functionality to configure the `dap` arguments, if you ever want to pass build tags and such to the command.
- Fixes a bug in the filter argument generation for ginkgo.
- Json report is using the absolute path now since the debugging was not supporting the `output-dir` argument properly.

I have battle tested this a bit and seems to work fine.

Please inform me whether this would an appropriate addition to this adapter and would like me to work on it more.