### PR TITLE
feat: add DescribeTableSubtree functionality to replicate tests

### DIFF
--- a/.selene.toml
+++ b/.selene.toml
@@ -1,0 +1,1 @@
+std = "lua52+vim"

--- a/lua/nvim-ginkgo/config.lua
+++ b/lua/nvim-ginkgo/config.lua
@@ -1,0 +1,41 @@
+local M = {}
+
+---@class nvim-ginkgo.Config
+---@field command string[]
+---@field dap nvim-ginkgo.ConfigDap
+
+---@class nvim-ginkgo.ConfigDap
+---@field args string[]
+
+---@type nvim-ginkgo.Config
+local defaults = {
+	command = {
+		"ginkgo",
+		"run",
+		"-v",
+	},
+	dap = {
+		args = {
+			"--ginkgo.v",
+		},
+	},
+}
+
+---@type nvim-ginkgo.Config
+---@diagnostic disable-next-line: missing-fields
+M.options = nil
+
+---@return nvim-ginkgo.Config
+function M.read()
+	return M.options or defaults
+end
+
+---@param config nvim-ginkgo.Config
+---@return nvim-ginkgo.Config
+function M.setup(config)
+	M.options = vim.tbl_deep_extend("force", {}, defaults, config or {})
+
+	return M.options
+end
+
+return M

--- a/lua/nvim-ginkgo/init.lua
+++ b/lua/nvim-ginkgo/init.lua
@@ -158,6 +158,7 @@ function adapter.results(spec, result, tree)
 		for _, spec_item in pairs(suite_item.SpecReports or {}) do
 			if spec_item.LeafNodeType == "It" then
 				local spec_item_node = {}
+				local spec_item_node_id = utils.create_location_id(spec_item)
 
 				if spec_item.State == "pending" then
 					spec_item_node.status = "skipped"
@@ -169,9 +170,10 @@ function adapter.results(spec, result, tree)
 					spec_item_node.status = spec_item.State
 				end
 
+				-- color definition
+				local spec_item_color = utils.get_color(spec_item)
 				-- set the node short attribute
-				spec_item_node.short = "[" .. string.upper(spec_item.State) .. "]"
-				spec_item_node.short = spec_item_node.short .. " " .. utils.create_spec_description(spec_item)
+				spec_item_node.short = utils.create_desc(spec_item, spec_item_color)
 				-- set the node location
 				spec_item_node.location = spec_item.LeafNodeLocation.LineNumber
 
@@ -192,14 +194,15 @@ function adapter.results(spec, result, tree)
 					spec_item_node.short = spec_item_node.short .. ": " .. err.message
 				elseif spec_item.CapturedGinkgoWriterOutput ~= nil then
 					-- prepare the output
-					local spec_output = utils.create_spec_output(spec_item)
+					local spec_output = utils.create_success_output(spec_item)
 					-- set the node output
 					spec_item_node.output = async.fn.tempname()
 					-- write the output
 					lib.files.write(spec_item_node.output, spec_output)
+				else
+					spec_item_node.short = nil
 				end
 
-				local spec_item_node_id = utils.create_location_id(spec_item)
 				-- set the node
 				collection[spec_item_node_id] = spec_item_node
 			end

--- a/lua/nvim-ginkgo/init.lua
+++ b/lua/nvim-ginkgo/init.lua
@@ -57,7 +57,13 @@ function adapter.discover_positions(file_path)
     )) @test.definition
   ]]
 
-	return lib.treesitter.parse_positions(file_path, query, { nested_namespaces = true, require_namespaces = true })
+	local options = {
+		nested_namespaces = true,
+		require_namespaces = true,
+		build_position = utils.create_position,
+	}
+
+	return lib.treesitter.parse_positions(file_path, query, options)
 end
 
 ---@param args neotest.RunArgs
@@ -106,7 +112,7 @@ function adapter.build_spec(args)
 	end
 
 	table.insert(cargs, directory .. plenary.path.sep .. "...")
-
+	-- done!
 	return {
 		command = table.concat(cargs, " "),
 		context = {

--- a/lua/nvim-ginkgo/init.lua
+++ b/lua/nvim-ginkgo/init.lua
@@ -46,14 +46,14 @@ function adapter.discover_positions(file_path)
     ; -- Namespaces --
     ; Matches: `describe('subject')` and `context('case')`
     ((call_expression
-      function: (identifier) @func_name (#any-of? @func_name "Describe" "DescribeTable" "Context" "When")
+      function: (identifier) @func_name (#any-of? @func_name "Describe" "FDescribe" "PDescribe" "XDescribe" "DescribeTable" "FDescribeTable" "PDescribeTable" "XDescribeTable" "Context" "FContext" "PContext" "XContext" "When" "FWhen" "PWhen" "XWhen")
       arguments: (argument_list ((interpreted_string_literal) @namespace.name))
     )) @namespace.definition
 
     ; -- Tests --
     ; Matches: `it('test')`
     ((call_expression
-      function: (identifier) @func_name (#any-of? @func_name "It" "Entry")
+      function: (identifier) @func_name (#any-of? @func_name "It" "FIt" "PIt" "XIt" "Specify" "FSpecify" "PSpecify" "XSpecify" "Entry" "FEntry" "PEntry" "XEntry")
       arguments: (argument_list ((interpreted_string_literal) @test.name))
     )) @test.definition
   ]]
@@ -158,19 +158,22 @@ function adapter.results(spec, result, tree)
 		for _, spec_item in pairs(suite_item.SpecReports or {}) do
 			if spec_item.LeafNodeType == "It" then
 				local spec_item_node = {}
-				-- set the node short attribute
-				spec_item_node.short = "[" .. string.upper(spec_item.State) .. "]"
-				spec_item_node.short = spec_item_node.short .. " " .. utils.create_spec_description(spec_item)
-				-- set the node location
-				spec_item_node.location = spec_item.LeafNodeLocation.LineNumber
 
 				if spec_item.State == "pending" then
 					spec_item_node.status = "skipped"
 				elseif spec_item.State == "panicked" then
 					spec_item_node.status = "failed"
+				elseif spec_item.State == "skipped" then
+					goto continue
 				else
 					spec_item_node.status = spec_item.State
 				end
+
+				-- set the node short attribute
+				spec_item_node.short = "[" .. string.upper(spec_item.State) .. "]"
+				spec_item_node.short = spec_item_node.short .. " " .. utils.create_spec_description(spec_item)
+				-- set the node location
+				spec_item_node.location = spec_item.LeafNodeLocation.LineNumber
 
 				-- set the node errors
 				if spec_item.Failure ~= nil then
@@ -200,6 +203,8 @@ function adapter.results(spec, result, tree)
 				-- set the node
 				collection[spec_item_node_id] = spec_item_node
 			end
+
+			::continue::
 		end
 	end
 

--- a/lua/nvim-ginkgo/init.lua
+++ b/lua/nvim-ginkgo/init.lua
@@ -74,13 +74,13 @@ function adapter.build_spec(args)
 	local report_directory = vim.fn.fnamemodify(report_path, ":h")
 	local cargs = {}
 
-	table.insert(cargs, "ginkgo")
-	table.insert(cargs, "run")
+	table.insert(cargs, "ginkgo run -v")
 	table.insert(cargs, "--keep-going")
 	table.insert(cargs, "--output-dir")
 	table.insert(cargs, report_directory)
 	table.insert(cargs, "--json-report")
 	table.insert(cargs, report_filename)
+	table.insert(cargs, "--silence-skips")
 
 	local position = args.tree:data()
 	local directory = position.path

--- a/lua/nvim-ginkgo/init.lua
+++ b/lua/nvim-ginkgo/init.lua
@@ -141,7 +141,7 @@ function adapter.build_spec(args)
 	}
 
 	if args.strategy == "dap" then
-		dap.setup_debugging(directory)
+		dap.check_dap_available()
 
 		local dap_args = vim.deepcopy(c.dap.args)
 

--- a/lua/nvim-ginkgo/init.lua
+++ b/lua/nvim-ginkgo/init.lua
@@ -5,7 +5,8 @@ local lib = require("neotest.lib")
 local logger = require("neotest.logging")
 local plenary = require("plenary.path")
 local query = require("nvim-ginkgo.query")
-local utils = require("nvim-ginkgo.utils")
+local output = require("nvim-ginkgo.output")
+local location = require("nvim-ginkgo.location")
 
 ---@class nvim-ginkgo.Adapter: neotest.Adapter
 ---@field setup fun(config: nvim-ginkgo.Config): nil
@@ -90,7 +91,7 @@ function adapter.build_spec(args)
 			-- replace the focus_file_path with its line number
 			focus_file_path = position.path .. ":" .. line_number
 			-- create the focus pattern
-			focus_pattern = utils.create_position_focus(position)
+			focus_pattern = location.create_position_focus(position)
 
 			vim.list_extend(cargs, { "--focus", focus_pattern })
 		end
@@ -183,7 +184,7 @@ function adapter.results(spec, result, tree)
 		for _, spec_item in pairs(suite_item.SpecReports or {}) do
 			if spec_item.LeafNodeType == "It" or spec_item.LeafNodeType == "Entry" then
 				local spec_item_node = {}
-				local spec_item_node_id = utils.create_location_id(spec_item)
+				local spec_item_node_id = location.create_location_id(spec_item)
 
 				if spec_item.State == "pending" then
 					spec_item_node.status = "skipped"
@@ -196,9 +197,9 @@ function adapter.results(spec, result, tree)
 				end
 
 				-- color definition
-				local spec_item_color = utils.get_color(spec_item)
+				local spec_item_color = output.get_color(spec_item)
 				-- set the node short attribute
-				spec_item_node.short = utils.create_desc(spec_item, spec_item_color)
+				spec_item_node.short = output.create_desc(spec_item, spec_item_color)
 				-- set the node location
 				spec_item_node.location = spec_item.LeafNodeLocation.LineNumber
 
@@ -206,11 +207,11 @@ function adapter.results(spec, result, tree)
 				if spec_item.Failure ~= nil then
 					spec_item_node.errors = {}
 
-					local err = utils.create_error(spec_item)
+					local err = output.create_error(spec_item)
 					-- add the error
 					table.insert(spec_item_node.errors, err)
 					-- prepare the output
-					local err_output = utils.create_error_output(spec_item)
+					local err_output = output.create_error_output(spec_item)
 					-- set the node output
 					spec_item_node.output = async.fn.tempname()
 					-- write the output
@@ -219,7 +220,7 @@ function adapter.results(spec, result, tree)
 					spec_item_node.short = spec_item_node.short .. ": " .. err.message
 				elseif spec_item.CapturedGinkgoWriterOutput ~= nil then
 					-- prepare the output
-					local spec_output = utils.create_success_output(spec_item)
+					local spec_output = output.create_success_output(spec_item)
 					-- set the node output
 					spec_item_node.output = async.fn.tempname()
 					-- write the output

--- a/lua/nvim-ginkgo/location.lua
+++ b/lua/nvim-ginkgo/location.lua
@@ -1,0 +1,44 @@
+local M = {}
+
+---@return string
+function M.create_location_id(spec)
+	local segments = {}
+	-- add the spec filename
+	table.insert(segments, spec.LeafNodeLocation.FileName)
+
+	local hierarchy = {}
+	for _, segment in pairs(spec.ContainerHierarchyTexts) do
+		table.insert(hierarchy, segment)
+	end
+
+	for _, segment in pairs(hierarchy) do
+		table.insert(segments, '"' .. segment .. '"')
+	end
+	-- add the spec text
+	table.insert(segments, '"' .. spec.LeafNodeText .. '"')
+
+	local id = table.concat(segments, "::")
+	-- done
+	return id
+end
+
+---@return string
+function M.create_location(spec)
+	return spec.FileName .. ":" .. spec.LineNumber
+end
+
+---Generate a Ginkgo focus pattern for a position
+---@param position neotest.Position
+---@return string
+function M.create_position_focus(position)
+	-- Build focus pattern from full position path
+	local name = string.sub(position.id, string.find(position.id, "::") + 2)
+	name = name:gsub("::", " ")
+	name = name:gsub('"', "")
+	name = name:gsub("/", "\\/")
+	name = name:gsub("([%.%+%-%*%?%[%]%(%)%$%^%|])", "\\%1")
+
+	return "\\b" .. name .. "\\b"
+end
+
+return M

--- a/lua/nvim-ginkgo/location.lua
+++ b/lua/nvim-ginkgo/location.lua
@@ -32,13 +32,22 @@ end
 ---@return string
 function M.create_position_focus(position)
 	-- Build focus pattern from full position path
+	local logger = require("neotest.logging")
+	logger.debug("create_position_focus: position.id = " .. position.id)
+	logger.debug("create_position_focus: position.name = " .. position.name)
+
 	local name = string.sub(position.id, string.find(position.id, "::") + 2)
+	logger.debug("create_position_focus: extracted name = " .. name)
+
 	name = name:gsub("::", " ")
 	name = name:gsub('"', "")
 	name = name:gsub("/", "\\/")
 	name = name:gsub("([%.%+%-%*%?%[%]%(%)%$%^%|])", "\\%1")
 
-	return "\\b" .. name .. "\\b"
+	local pattern = "\\b" .. name .. "\\b"
+	logger.debug("create_position_focus: final pattern = " .. pattern)
+
+	return pattern
 end
 
 return M

--- a/lua/nvim-ginkgo/query.lua
+++ b/lua/nvim-ginkgo/query.lua
@@ -1,38 +1,33 @@
 local lib = require("neotest.lib")
 local logger = require("neotest.logging")
+local Tree = require("neotest.types").Tree
 
 local M = {}
 
--- Get the plugin root directory.
+-- Get the plugin root directory
 local plugin_root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h")
 
--- Module-level cache for loaded queries.
+-- Module-level cache for loaded queries
 local query_cache = {}
 
---- Load a query file from the queries directory.
---- @param path string Relative path to query file.
+--- Load a query file from the queries directory
+--- @param path string Relative path to query file
 --- @return string Query content
 local function load(path)
 	if query_cache[path] then
-		logger.debug("Query loaded from cache: " .. path)
 		return query_cache[path]
 	end
 
 	local absolute_path = plugin_root .. "/" .. path
-
-	logger.debug("Attempting to load query from: " .. absolute_path)
-
 	local file = io.open(absolute_path, "r")
+
 	if not file then
-		logger.error("Could not open query file: " .. absolute_path .. " (plugin_root: " .. plugin_root .. ")")
+		logger.error("Could not open query file: " .. absolute_path)
 		return ""
 	end
 
 	local content = file:read("*all")
 	file:close()
-
-	logger.debug("Loaded query " .. path .. ": " .. #content .. " bytes")
-
 	query_cache[path] = content
 
 	return content
@@ -43,13 +38,12 @@ local queries = {
 	load("queries/go/test.scm"),
 }
 
---- Clear the query cache.
---- @return nil
+--- Clear the query cache
 function M.flush_cache()
 	query_cache = {}
 end
 
---- Check if the required parsers are available.
+--- Check if the required parsers are available
 --- @return boolean
 function M.has_parser()
 	if vim.treesitter.language and vim.treesitter.language.add then
@@ -60,83 +54,266 @@ function M.has_parser()
 	return false
 end
 
----@type fun(file_path: string, source: string, captured_nodes: table<string, userdata>, metadata: table<string, vim.treesitter.query.TSMetadata>): neotest.Position|neotest.Position[]|nil Builds one or more positions from the captured nodes from a query match.
-function M.build_position(path, source, captured_nodes)
-	local function get_match_type()
-		if captured_nodes["test.name"] then
-			return "test"
-		end
-		if captured_nodes["namespace.name"] then
-			return "namespace"
-		end
+--- Check if an Entry node is inside a DescribeTableSubtree
+--- @param definition userdata The call_expression node
+--- @param source string Source content
+--- @return boolean
+local function is_entry_in_describe_table_subtree(definition, source)
+	local parent = definition:parent()
+	if not parent or parent:type() ~= "argument_list" then
+		return false
 	end
 
-	local match_type = get_match_type()
-	-- if we have a match
-	if match_type then
-		---@type string
-		local name = vim.treesitter.get_node_text(captured_nodes[match_type .. ".name"], source)
-		local match_name = vim.treesitter.get_node_text(captured_nodes["func_name"], source)
-		local definition = captured_nodes[match_type .. ".definition"]
+	local grandparent = parent:parent()
+	if not grandparent or grandparent:type() ~= "call_expression" then
+		return false
+	end
 
-		-- Special handling for Entry: determine type based on parent context
-		if match_name:match("^[FPX]?Entry$") then
-			logger.debug("Found Entry: " .. name)
-			-- The definition node is the Entry call_expression
-			-- Its parent is argument_list, and that argument_list's parent is the containing call_expression
-			local arg_list = definition:parent()
-			logger.debug("Parent type: " .. (arg_list and arg_list:type() or "nil"))
+	local func_field = grandparent:field("function")
+	if not func_field or not func_field[1] then
+		return false
+	end
+
+	local parent_func_name = vim.treesitter.get_node_text(func_field[1], source)
+
+	return parent_func_name:match("^[FPX]?DescribeTableSubtree$") ~= nil
+end
+
+--- Build a position from captured treesitter nodes
+--- @param path string File path
+--- @param source string Source content
+--- @param captured_nodes table Captured nodes from query
+--- @return neotest.Position|nil
+function M.build_position(path, source, captured_nodes)
+	local match_type
+	if captured_nodes["test.name"] then
+		match_type = "test"
+	elseif captured_nodes["namespace.name"] then
+		match_type = "namespace"
+	else
+		return nil
+	end
+
+	local name = vim.treesitter.get_node_text(captured_nodes[match_type .. ".name"], source)
+	local match_name = vim.treesitter.get_node_text(captured_nodes["func_name"], source)
+	local definition = captured_nodes[match_type .. ".definition"]
+
+	-- Skip Entry nodes inside DescribeTableSubtree (they'll be parsed manually during restructure)
+	if match_name:match("^[FPX]?Entry$") and is_entry_in_describe_table_subtree(definition, source) then
+		return nil
+	end
+
+	-- Remove quotes from name
+	name = name:gsub('"', "")
+
+	-- Special formatting for When
+	if match_name == "When" then
+		name = string.lower(match_name) .. " " .. name
+	end
+
+	-- Create position
+	local range
+	if match_name:match("^[FPX]?DescribeTableSubtree$") then
+		-- Extend range to include all Entry arguments
+		local args = definition:field("arguments")
+		if args and args[1] then
+			local arg_list = args[1]
+			local start_row, start_col, _, _ = definition:range()
+			local _, _, end_row, end_col = arg_list:range()
+			range = { start_row, start_col, end_row, end_col }
+		else
+			range = { definition:range() }
+		end
+	else
+		range = { definition:range() }
+	end
+
+	return {
+		type = match_type,
+		path = path,
+		name = '"' .. name .. '"',
+		range = range,
+	}
+end
+
+--- Parse Entry nodes from source within a given range
+--- @param source string Source content
+--- @param range table Range to search within
+--- @return table[] Array of entry info {name, range}
+local function parse_entries_from_source(source, range)
+	local parser = vim.treesitter.get_string_parser(source, "go")
+	local tree = parser:parse()[1]
+	local root = tree:root()
+
+	local query = vim.treesitter.query.parse("go", load("queries/go/entry.scm"))
+	local entries = {}
+
+	for id, node in query:iter_captures(root, source, range[1], range[3] + 1) do
+		local name = query.captures[id]
+		if name == "entry.name" then
+			local entry_name = vim.treesitter.get_node_text(node, source):gsub('"', "")
+			local parent = node:parent():parent() -- call_expression
+			local start_row, start_col, end_row, end_col = parent:range()
+
+			-- Verify this Entry belongs to a DescribeTableSubtree
+			local arg_list = parent:parent()
 			if arg_list and arg_list:type() == "argument_list" then
-				local parent_call = arg_list:parent()
-				logger.debug("Grandparent type: " .. (parent_call and parent_call:type() or "nil"))
-				if parent_call and parent_call:type() == "call_expression" then
-					local func_field = parent_call:field("function")
-					if func_field and func_field[1] then
-						local parent_func_name = vim.treesitter.get_node_text(func_field[1], source)
-						logger.debug("Parent function: " .. parent_func_name)
-						-- If parent is DescribeTableSubtree, Entry should be a namespace
-						if parent_func_name:match("^[FPX]?DescribeTableSubtree$") then
-							match_type = "namespace"
-							logger.debug("Changed Entry to namespace")
-						-- If parent is DescribeTable, Entry should be a test
-						elseif parent_func_name:match("^[FPX]?DescribeTable$") then
-							match_type = "test"
-							logger.debug("Kept Entry as test (DescribeTable)")
+				local desc_call = arg_list:parent()
+				if desc_call and desc_call:type() == "call_expression" then
+					local func_node = desc_call:field("function")
+					if func_node and func_node[1] then
+						local func_name = vim.treesitter.get_node_text(func_node[1], source)
+						if func_name:match("^[FPX]?DescribeTableSubtree$") then
+							table.insert(entries, {
+								name = '"' .. entry_name .. '"',
+								range = { start_row, start_col, end_row, end_col },
+							})
 						end
 					end
 				end
 			end
 		end
-
-		name, _ = string.gsub(name, '"', "")
-		-- prepare the name
-		if match_name == "When" then
-			name = string.lower(match_name) .. " " .. name
-		end
-
-		return {
-			type = match_type,
-			path = path,
-			name = '"' .. name .. '"',
-			range = { definition:range() },
-		}
 	end
+
+	return entries
 end
 
---- Detect Ginkgo tests in a file.
+--- Update IDs in a tree to insert a new parent in the hierarchy
+--- @param tree neotest.Tree
+--- @param parent_id string The parent ID to insert after
+--- @param insert_segment string The segment to insert
+--- @return neotest.Tree
+local function update_tree_ids(tree, parent_id, insert_segment)
+	local data = tree:data()
+
+	-- Create a copy of the data to avoid mutating the original
+	local new_data = {}
+	for k, v in pairs(data) do
+		new_data[k] = v
+	end
+
+	-- Update this node's ID by inserting the new segment after parent_id
+	if new_data.id:find(parent_id, 1, true) then
+		new_data.id = new_data.id:gsub("^(" .. vim.pesc(parent_id) .. ")(::)", "%1::" .. insert_segment .. "%2")
+	end
+
+	-- Recursively update children
+	local children = tree:children()
+	if #children > 0 then
+		local new_children = {}
+		for _, child in ipairs(children) do
+			table.insert(new_children, update_tree_ids(child, parent_id, insert_segment))
+		end
+		return Tree:new(new_data, new_children, tree._key, nil, tree._nodes)
+	end
+
+	return Tree:new(new_data, {}, tree._key, nil, tree._nodes)
+end
+
+--- Post-process tree to duplicate body tests under DescribeTableSubtree Entry namespaces
+--- @param tree neotest.Tree
+--- @param source string Source content
+--- @return neotest.Tree
+local function restructure_describe_table_subtree(tree, source)
+	local data = tree:data()
+
+	-- Check if this is a DescribeTableSubtree by looking for Entry nodes in its range
+	if data.type == "namespace" then
+		local entries = parse_entries_from_source(source, data.range)
+
+		if #entries > 0 then
+			-- This is a DescribeTableSubtree - first recursively process all children
+			local children = tree:children()
+			local processed_children = {}
+			for _, child in ipairs(children) do
+				table.insert(processed_children, restructure_describe_table_subtree(child, source))
+			end
+
+			-- Calculate ranges for Entry namespaces
+			-- First Entry gets range from DescribeTableSubtree start to first Entry end
+			-- Other Entries get range from their Entry line only
+			local body_start_row = data.range[1]
+
+			-- Now duplicate the processed children under each Entry
+			local new_children = {}
+			for i, entry_info in ipairs(entries) do
+				local entry_range
+				if i == 1 then
+					-- First Entry: range from body start through this Entry
+					entry_range = { body_start_row, data.range[2], entry_info.range[3], entry_info.range[4] }
+				else
+					-- Other Entries: just their own line
+					entry_range = entry_info.range
+				end
+
+				local entry_data = {
+					type = "namespace",
+					path = data.path,
+					name = entry_info.name,
+					range = entry_range,
+					id = data.path .. "::" .. data.name .. "::" .. entry_info.name,
+				}
+
+				-- Duplicate all processed body nodes under this Entry
+				local entry_children = {}
+				for _, processed_node in ipairs(processed_children) do
+					-- Update the IDs to include the Entry name in the hierarchy
+					local updated = update_tree_ids(processed_node, data.id, entry_info.name)
+					table.insert(entry_children, updated)
+				end
+
+				local entry_tree = Tree:new(entry_data, entry_children, tree._key, nil, tree._nodes)
+				table.insert(new_children, entry_tree)
+			end
+
+			return Tree:new(data, new_children, tree._key, nil, tree._nodes)
+		end
+	end
+
+	-- Recursively process children
+	local children = tree:children()
+	if #children > 0 then
+		local new_children = {}
+		for _, child in ipairs(children) do
+			table.insert(new_children, restructure_describe_table_subtree(child, source))
+		end
+		return Tree:new(data, new_children, tree._key, nil, tree._nodes)
+	end
+
+	return tree
+end
+
+--- Detect Ginkgo tests in a file
 --- @param path string Absolute path to the Go test file
 --- @return neotest.Tree|nil Tree of detected tests, or nil if parsing failed
 function M.parse(path)
 	if not M.has_parser() then
-		logger.error("Go tree-sitter parser not found. Install with :TSInstall go", true)
+		logger.error("Go tree-sitter parser not found. Install with :TSInstall go")
 		return nil
 	end
 
-	return lib.treesitter.parse_positions(path, table.concat(queries, "\n"), {
+	-- Read source content
+	local file = io.open(path, "r")
+	if not file then
+		logger.error("Could not open file: " .. path)
+		return nil
+	end
+	local source = file:read("*all")
+	file:close()
+
+	-- Parse positions using treesitter queries
+	local tree = lib.treesitter.parse_positions(path, table.concat(queries, "\n"), {
 		nested_namespaces = true,
-		require_namespaces = true,
+		require_namespaces = false,
 		build_position = M.build_position,
 	})
+
+	if not tree then
+		return nil
+	end
+
+	-- Post-process to handle DescribeTableSubtree
+	return restructure_describe_table_subtree(tree, source)
 end
 
 return M

--- a/lua/nvim-ginkgo/query.lua
+++ b/lua/nvim-ginkgo/query.lua
@@ -1,6 +1,5 @@
 local lib = require("neotest.lib")
 local logger = require("neotest.logging")
-local utils = require("nvim-ginkgo.utils")
 
 local M = {}
 
@@ -61,6 +60,69 @@ function M.has_parser()
 	return false
 end
 
+---@type fun(file_path: string, source: string, captured_nodes: table<string, userdata>, metadata: table<string, vim.treesitter.query.TSMetadata>): neotest.Position|neotest.Position[]|nil Builds one or more positions from the captured nodes from a query match.
+function M.build_position(path, source, captured_nodes)
+	local function get_match_type()
+		if captured_nodes["test.name"] then
+			return "test"
+		end
+		if captured_nodes["namespace.name"] then
+			return "namespace"
+		end
+	end
+
+	local match_type = get_match_type()
+	-- if we have a match
+	if match_type then
+		---@type string
+		local name = vim.treesitter.get_node_text(captured_nodes[match_type .. ".name"], source)
+		local match_name = vim.treesitter.get_node_text(captured_nodes["func_name"], source)
+		local definition = captured_nodes[match_type .. ".definition"]
+
+		-- Special handling for Entry: determine type based on parent context
+		if match_name:match("^[FPX]?Entry$") then
+			logger.debug("Found Entry: " .. name)
+			-- The definition node is the Entry call_expression
+			-- Its parent is argument_list, and that argument_list's parent is the containing call_expression
+			local arg_list = definition:parent()
+			logger.debug("Parent type: " .. (arg_list and arg_list:type() or "nil"))
+			if arg_list and arg_list:type() == "argument_list" then
+				local parent_call = arg_list:parent()
+				logger.debug("Grandparent type: " .. (parent_call and parent_call:type() or "nil"))
+				if parent_call and parent_call:type() == "call_expression" then
+					local func_field = parent_call:field("function")
+					if func_field and func_field[1] then
+						local parent_func_name = vim.treesitter.get_node_text(func_field[1], source)
+						logger.debug("Parent function: " .. parent_func_name)
+						-- If parent is DescribeTableSubtree, Entry should be a namespace
+						if parent_func_name:match("^[FPX]?DescribeTableSubtree$") then
+							match_type = "namespace"
+							logger.debug("Changed Entry to namespace")
+						-- If parent is DescribeTable, Entry should be a test
+						elseif parent_func_name:match("^[FPX]?DescribeTable$") then
+							match_type = "test"
+							logger.debug("Kept Entry as test (DescribeTable)")
+						end
+					end
+				end
+			end
+		end
+
+		name, _ = string.gsub(name, '"', "")
+		-- prepare the name
+		if match_name == "When" then
+			name = string.lower(match_name) .. " " .. name
+		end
+
+		return {
+			type = match_type,
+			path = path,
+			name = '"' .. name .. '"',
+			range = { definition:range() },
+		}
+	end
+end
+
 --- Detect Ginkgo tests in a file.
 --- @param path string Absolute path to the Go test file
 --- @return neotest.Tree|nil Tree of detected tests, or nil if parsing failed
@@ -73,7 +135,7 @@ function M.parse(path)
 	return lib.treesitter.parse_positions(path, table.concat(queries, "\n"), {
 		nested_namespaces = true,
 		require_namespaces = true,
-		build_position = utils.create_position,
+		build_position = M.build_position,
 	})
 end
 

--- a/lua/nvim-ginkgo/query.lua
+++ b/lua/nvim-ginkgo/query.lua
@@ -1,0 +1,80 @@
+local lib = require("neotest.lib")
+local logger = require("neotest.logging")
+local utils = require("nvim-ginkgo.utils")
+
+local M = {}
+
+-- Get the plugin root directory.
+local plugin_root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h")
+
+-- Module-level cache for loaded queries.
+local query_cache = {}
+
+--- Load a query file from the queries directory.
+--- @param path string Relative path to query file.
+--- @return string Query content
+local function load(path)
+	if query_cache[path] then
+		logger.debug("Query loaded from cache: " .. path)
+		return query_cache[path]
+	end
+
+	local absolute_path = plugin_root .. "/" .. path
+
+	logger.debug("Attempting to load query from: " .. absolute_path)
+
+	local file = io.open(absolute_path, "r")
+	if not file then
+		logger.error("Could not open query file: " .. absolute_path .. " (plugin_root: " .. plugin_root .. ")")
+		return ""
+	end
+
+	local content = file:read("*all")
+	file:close()
+
+	logger.debug("Loaded query " .. path .. ": " .. #content .. " bytes")
+
+	query_cache[path] = content
+
+	return content
+end
+
+local queries = {
+	load("queries/go/namespace.scm"),
+	load("queries/go/test.scm"),
+}
+
+--- Clear the query cache.
+--- @return nil
+function M.flush_cache()
+	query_cache = {}
+end
+
+--- Check if the required parsers are available.
+--- @return boolean
+function M.has_parser()
+	if vim.treesitter.language and vim.treesitter.language.add then
+		return pcall(function()
+			vim.treesitter.language.add("go")
+		end)
+	end
+	return false
+end
+
+--- Detect Ginkgo tests in a file.
+--- @param path string Absolute path to the Go test file
+--- @return neotest.Tree|nil Tree of detected tests, or nil if parsing failed
+function M.parse(path)
+	if not M.has_parser() then
+		logger.error("Go tree-sitter parser not found. Install with :TSInstall go", true)
+		return nil
+	end
+
+	return lib.treesitter.parse_positions(path, table.concat(queries, "\n"), {
+		nested_namespaces = true,
+		require_namespaces = true,
+		build_position = utils.create_position,
+	})
+end
+
+return M

--- a/lua/nvim-ginkgo/strategies/dap.lua
+++ b/lua/nvim-ginkgo/strategies/dap.lua
@@ -1,0 +1,46 @@
+local M = {}
+
+local logger = require("neotest.logging")
+
+---This will prepare and setup nvim-dap-go for debugging.
+---@param cwd string
+function M.setup_debugging(cwd)
+	local ok, adapter = pcall(require, "dap-go")
+	if not ok then
+		local msg = "You must have leoluz/nvim-dap-go installed to use DAP strategy. "
+			.. "See the neotest-golang README for more information."
+		logger.error(msg)
+		error(msg)
+	end
+
+	local opts = {
+		delve = {
+			cwd = cwd,
+		},
+	}
+	logger.debug({ "Setting up dap-go for DAP: ", opts })
+
+	adapter.setup(opts)
+end
+
+--- @param path string
+--- @param args string[]?
+--- @return table | nil
+function M.get_dap_config(path, args)
+	-- :help dap-configuration
+	local config = {
+		type = "go",
+		name = "Neotest-golang",
+		request = "launch",
+		mode = "test",
+		program = path,
+		args = args,
+		outputMode = "remote",
+	}
+
+	logger.debug({ "DAP configuration: ", config })
+
+	return config
+end
+
+return M

--- a/lua/nvim-ginkgo/strategies/dap.lua
+++ b/lua/nvim-ginkgo/strategies/dap.lua
@@ -2,39 +2,29 @@ local M = {}
 
 local logger = require("neotest.logging")
 
----This will prepare and setup nvim-dap-go for debugging.
----@param cwd string
-function M.setup_debugging(cwd)
-	local ok, adapter = pcall(require, "dap-go")
+---Checks if dap-go is available for debugging.
+function M.check_dap_available()
+	local ok, _ = pcall(require, "dap-go")
 	if not ok then
-		local msg = "You must have leoluz/nvim-dap-go installed to use DAP strategy. "
-			.. "See the neotest-golang README for more information."
+		local msg = "You must have leoluz/nvim-dap-go installed to use DAP strategy."
 		logger.error(msg)
 		error(msg)
 	end
-
-	local opts = {
-		delve = {
-			cwd = cwd,
-		},
-	}
-	logger.debug({ "Setting up dap-go for DAP: ", opts })
-
-	adapter.setup(opts)
 end
 
---- @param path string
---- @param args string[]?
---- @return table | nil
-function M.get_dap_config(path, args)
+---@param cwd string
+---@param args string[]?
+---@return table
+function M.get_dap_config(cwd, args)
 	-- :help dap-configuration
 	local config = {
 		type = "go",
-		name = "Neotest-golang",
+		name = "nvim-ginkgo",
 		request = "launch",
 		mode = "test",
-		program = path,
+		program = cwd,
 		args = args,
+		cwd = cwd,
 		outputMode = "remote",
 	}
 

--- a/lua/nvim-ginkgo/utils.lua
+++ b/lua/nvim-ginkgo/utils.lua
@@ -229,7 +229,7 @@ function utils.create_position_focus(position)
 	name, _ = string.gsub(name, '"', "")
 	-- prepare the pattern
 	-- https://github.com/onsi/ginkgo/issues/1126#issuecomment-1409245937
-	return "'\\b" .. name .. "\\b'"
+	return "\\b" .. name .. "\\b"
 end
 
 return utils

--- a/lua/nvim-ginkgo/utils.lua
+++ b/lua/nvim-ginkgo/utils.lua
@@ -183,4 +183,16 @@ function utils.create_location(spec)
 	return spec.FileName .. ":" .. spec.LineNumber
 end
 
+---@param position neotest.Position
+---@return string
+function utils.create_position_focus(position)
+	-- pos.id in form "path/to/file::Describe text::test text"
+	local name = string.sub(position.id, string.find(position.id, "::") + 2)
+	name, _ = string.gsub(name, "::", " ")
+	name, _ = string.gsub(name, '"', "")
+	-- prepare the pattern
+	-- https://github.com/onsi/ginkgo/issues/1126#issuecomment-1409245937
+	return "'\\b" .. name .. "\\b'"
+end
+
 return utils

--- a/lua/nvim-ginkgo/utils.lua
+++ b/lua/nvim-ginkgo/utils.lua
@@ -227,9 +227,9 @@ function utils.create_position_focus(position)
 	local name = string.sub(position.id, string.find(position.id, "::") + 2)
 	name, _ = string.gsub(name, "::", " ")
 	name, _ = string.gsub(name, '"', "")
-	-- TODO: there is a problem with slashes for sure!
+	-- escape forward slashes for regex pattern matching
 	name, _ = string.gsub(name, "/", "\\/")
-	-- escape some pattern characters
+	-- escape regex special characters
 	name, _ = string.gsub(name, "([%.%+%-%*%?%[%]%(%)%$%^%|])", "\\%1")
 
 	-- prepare the pattern

--- a/lua/nvim-ginkgo/utils.lua
+++ b/lua/nvim-ginkgo/utils.lua
@@ -227,9 +227,14 @@ function utils.create_position_focus(position)
 	local name = string.sub(position.id, string.find(position.id, "::") + 2)
 	name, _ = string.gsub(name, "::", " ")
 	name, _ = string.gsub(name, '"', "")
+	-- TODO: there is a problem with slashes for sure!
+	name, _ = string.gsub(name, "/", "\\/")
+	-- escape some pattern characters
+	name, _ = string.gsub(name, "([%.%+%-%*%?%[%]%(%)%$%^%|])", "\\%1")
+
 	-- prepare the pattern
 	-- https://github.com/onsi/ginkgo/issues/1126#issuecomment-1409245937
-	return "'\\b" .. name .. "\\b'"
+	return "\\b" .. name .. "\\b"
 end
 
 return utils

--- a/lua/nvim-ginkgo/utils.lua
+++ b/lua/nvim-ginkgo/utils.lua
@@ -227,6 +227,11 @@ function utils.create_position_focus(position)
 	local name = string.sub(position.id, string.find(position.id, "::") + 2)
 	name, _ = string.gsub(name, "::", " ")
 	name, _ = string.gsub(name, '"', "")
+	-- TODO: there is a problem with slashes for sure!
+	name, _ = string.gsub(name, "/", "\\/")
+	-- escape some pattern characters
+	name, _ = string.gsub(name, "([%.%+%-%*%?%[%]%(%)%$%^%|])", "\\%1")
+
 	-- prepare the pattern
 	-- https://github.com/onsi/ginkgo/issues/1126#issuecomment-1409245937
 	return "\\b" .. name .. "\\b"

--- a/queries/go/entry.scm
+++ b/queries/go/entry.scm
@@ -1,0 +1,5 @@
+((call_expression
+  function: (identifier) @func_name
+  arguments: (argument_list . (interpreted_string_literal) @entry.name))
+  (#any-of? @func_name "Entry" "FEntry" "PEntry" "XEntry"))
+  @entry.definition

--- a/queries/go/namespace.scm
+++ b/queries/go/namespace.scm
@@ -3,7 +3,8 @@
   arguments: (argument_list . (interpreted_string_literal) @namespace.name))
   (#any-of? @func_name
     "Describe" "FDescribe" "PDescribe" "XDescribe"
-    "DescribeTable" "FDescribeTable" "PDescribeTable" "XDescribeTable"
     "Context" "FContext" "PContext" "XContext"
     "When" "FWhen" "PWhen" "XWhen"
+    "DescribeTable" "FDescribeTable" "PDescribeTable" "XDescribeTable"
+    "DescribeTableSubtree" "FDescribeTableSubtree" "PDescribeTableSubtree" "XDescribeTableSubtree"
   )) @namespace.definition

--- a/queries/go/namespace.scm
+++ b/queries/go/namespace.scm
@@ -1,0 +1,9 @@
+((call_expression
+  function: (identifier) @func_name
+  arguments: (argument_list . (interpreted_string_literal) @namespace.name))
+  (#any-of? @func_name
+    "Describe" "FDescribe" "PDescribe" "XDescribe"
+    "DescribeTable" "FDescribeTable" "PDescribeTable" "XDescribeTable"
+    "Context" "FContext" "PContext" "XContext"
+    "When" "FWhen" "PWhen" "XWhen"
+  )) @namespace.definition

--- a/queries/go/test.scm
+++ b/queries/go/test.scm
@@ -4,11 +4,5 @@
   (#any-of? @func_name
     "It" "FIt" "PIt" "XIt"
     "Specify" "FSpecify" "PSpecify" "XSpecify"
-  )) @test.definition
-
-(call_expression
-  function: (identifier) @func_name
-  arguments: (argument_list . (interpreted_string_literal) @test.name)
-  (#any-of? @func_name
     "Entry" "FEntry" "PEntry" "XEntry"
   )) @test.definition

--- a/queries/go/test.scm
+++ b/queries/go/test.scm
@@ -6,9 +6,9 @@
     "Specify" "FSpecify" "PSpecify" "XSpecify"
   )) @test.definition
 
-((call_expression
+(call_expression
   function: (identifier) @func_name
-  arguments: (argument_list . (interpreted_string_literal) @test.name))
+  arguments: (argument_list . (interpreted_string_literal) @test.name)
   (#any-of? @func_name
     "Entry" "FEntry" "PEntry" "XEntry"
   )) @test.definition

--- a/queries/go/test.scm
+++ b/queries/go/test.scm
@@ -1,0 +1,14 @@
+((call_expression
+  function: (identifier) @func_name
+  arguments: (argument_list . (interpreted_string_literal) @test.name))
+  (#any-of? @func_name
+    "It" "FIt" "PIt" "XIt"
+    "Specify" "FSpecify" "PSpecify" "XSpecify"
+  )) @test.definition
+
+((call_expression
+  function: (identifier) @func_name
+  arguments: (argument_list . (interpreted_string_literal) @test.name))
+  (#any-of? @func_name
+    "Entry" "FEntry" "PEntry" "XEntry"
+  )) @test.definition


### PR DESCRIPTION
I hope this addition would also be acceptable by you.

- Add `DescribeTableSubtree` support which replicates the tests to multiple instances.
- Separates the query parsing into its own mechanism to have the power of `treesitter` itself to validate the queries.

For the life of me I could not do this in one go with treesitter itself since the `DescribeTableSubtree` and its `Entry` are all siblings, therefore it would not replicate over the tests so has a kind of postprocessing hack.