### PR TITLE
fix: replace vim.fn.glob with uv.fs_readdir in filter_dir

### DIFF
--- a/lua/neotest-ginkgo/init.lua
+++ b/lua/neotest-ginkgo/init.lua
@@ -35,19 +35,38 @@ end
 ---@param rel_path string Path to directory, relative to root
 ---@param root string Root directory of project
 ---@return boolean
+---Recursively check whether a directory contains a Ginkgo suite file
+---Uses libuv fs directly because vim.fn.glob cannot be called in async context
+---@param dir string Absolute directory path to search
+---@return boolean
+local function has_suite_file(dir)
+	local uv = vim.uv or vim.loop
+	local handle = uv.fs_opendir(dir, nil, 100)
+	if not handle then
+		return false
+	end
+	local entries = uv.fs_readdir(handle)
+	uv.fs_closedir(handle)
+	for _, entry in ipairs(entries or {}) do
+		if entry.type == "file" then
+			if entry.name == "suite_test.go" or vim.endswith(entry.name, "_suite_test.go") then
+				return true
+			end
+		elseif entry.type == "directory" and entry.name ~= "vendor" then
+			if has_suite_file(dir .. "/" .. entry.name) then
+				return true
+			end
+		end
+	end
+	return false
+end
+
 function adapter.filter_dir(name, rel_path, root)
 	if name == "vendor" then
 		return false
 	end
 	local dir_path = root .. plenary.path.sep .. rel_path
-	local suite_file = dir_path .. plenary.path.sep .. "suite_test.go"
-	local named_suite_file = dir_path .. plenary.path.sep .. name .. "_suite_test.go"
-	if vim.fn.filereadable(suite_file) == 1 or vim.fn.filereadable(named_suite_file) == 1 then
-		return true
-	end
-	-- Allow intermediate directories that contain suite files deeper in the tree
-	return #vim.fn.glob(dir_path .. "/**/suite_test.go", false, true) > 0
-		or #vim.fn.glob(dir_path .. "/**/*_suite_test.go", false, true) > 0
+	return has_suite_file(dir_path)
 end
 
 ---@async

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -1,0 +1,90 @@
+-- Tests for init.lua (adapter interface)
+
+---@diagnostic disable: undefined-field
+
+local nio_tests = require("nio.tests")
+local async = require("neotest.async")
+local adapter = require("neotest-ginkgo")
+
+---Create a directory tree and return its root path
+---@param structure table<string, string|boolean> Map of relative paths to content (string) or dir (true)
+---@return string Root temp directory
+local function make_dir_tree(structure)
+	local root = async.fn.tempname()
+	vim.fn.mkdir(root, "p")
+	for rel, content in pairs(structure) do
+		local full = root .. "/" .. rel
+		local dir = vim.fn.fnamemodify(full, ":h")
+		vim.fn.mkdir(dir, "p")
+		if type(content) == "string" then
+			vim.fn.writefile({ content }, full)
+		end
+	end
+	return root
+end
+
+describe("adapter.filter_dir", function()
+	nio_tests.it("returns true for directory with suite_test.go", function()
+		local root = make_dir_tree({
+			["pkg/suite_test.go"] = "package pkg_test",
+		})
+
+		assert.is_true(adapter.filter_dir("pkg", "pkg", root))
+
+		async.fn.delete(root, "rf")
+	end)
+
+	nio_tests.it("returns true for directory with {name}_suite_test.go", function()
+		local root = make_dir_tree({
+			["service/service_suite_test.go"] = "package service_test",
+		})
+
+		assert.is_true(adapter.filter_dir("service", "service", root))
+
+		async.fn.delete(root, "rf")
+	end)
+
+	nio_tests.it("returns true for intermediate directory containing suite files deeper", function()
+		local root = make_dir_tree({
+			["internal/database/pg/suite_test.go"] = "package pg_test",
+		})
+
+		-- internal/ has no suite file directly, but contains one in a subdirectory
+		assert.is_true(adapter.filter_dir("internal", "internal", root))
+		assert.is_true(adapter.filter_dir("database", "internal/database", root))
+
+		async.fn.delete(root, "rf")
+	end)
+
+	nio_tests.it("returns false for directory with no suite files", function()
+		local root = make_dir_tree({
+			["cmd/main.go"] = "package main",
+		})
+
+		assert.is_false(adapter.filter_dir("cmd", "cmd", root))
+
+		async.fn.delete(root, "rf")
+	end)
+
+	nio_tests.it("returns false for vendor directory", function()
+		local root = make_dir_tree({
+			["vendor/suite_test.go"] = "package vendor_test",
+		})
+
+		assert.is_false(adapter.filter_dir("vendor", "vendor", root))
+
+		async.fn.delete(root, "rf")
+	end)
+
+	nio_tests.it("does not recurse into vendor subdirectories", function()
+		local root = make_dir_tree({
+			["internal/vendor/pkg/suite_test.go"] = "package pkg_test",
+		})
+
+		-- internal/ contains vendor/ which contains a suite file,
+		-- but vendor should not be traversed
+		assert.is_false(adapter.filter_dir("internal", "internal", root))
+
+		async.fn.delete(root, "rf")
+	end)
+end)


### PR DESCRIPTION
## Summary

- `vim.fn.glob` cannot be called in async (fast event) context — neotest calls `filter_dir` from an async task, causing a hard error that prevented any test positions from being discovered for project-level runs
- Replace with a recursive `vim.uv.fs_readdir` scan that is async-safe
- Vendor directories are skipped during recursion to avoid false positives

## Root cause

```
ERROR | Couldn't find positions in path ...
...neotest-ginkgo/init.lua:49: E5560: Vimscript function "glob" must not be called in a fast event context
```

## Test plan

- [x] All existing tests pass (`make test`)
- [x] New `tests/init_spec.lua` covers: direct suite file, named suite file, intermediate directories, empty dirs, vendor exclusion, nested vendor exclusion
- [x] Project-level run on `grpc-go-template` discovers and runs all test suites